### PR TITLE
Added Alarm/Compare Interrupt Functionality

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -64,7 +64,8 @@ void RTCZero::begin(bool timeRep)
   NVIC_EnableIRQ(RTC_IRQn); // enable RTC interrupt 
   NVIC_SetPriority(RTC_IRQn, 0x00);
 
-  RTC->MODE2.INTENSET.reg &= ~RTC_MODE2_INTENSET_ALARM0; // disable alarm interrupt by default
+  RTC->MODE2.INTENSET.reg |= RTC_MODE2_INTENSET_ALARM0; // enable alarm interrupt
+  RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = MATCH_OFF; // default alarm match is off (disabled)
   
   while (RTCisSyncing())
     ;
@@ -76,6 +77,20 @@ void RTCZero::begin(bool timeRep)
 void RTC_Handler(void)
 {
   RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0; // must clear flag at end
+}
+
+void RTCZero::enableAlarm(Alarm_Match match)
+{
+  RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = match;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::disableAlarm()
+{
+  RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = 0x00;
+  while (RTCisSyncing())
+    ;
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -61,8 +61,21 @@ void RTCZero::begin(bool timeRep)
   while (RTCisSyncing())
     ;
 
+  NVIC_EnableIRQ(RTC_IRQn); // enable RTC interrupt 
+  NVIC_SetPriority(RTC_IRQn, 0x00);
+
+  RTC->MODE2.INTENSET.reg &= ~RTC_MODE2_INTENSET_ALARM0; // disable alarm interrupt by default
+  
+  while (RTCisSyncing())
+    ;
+
   RTCenable();
   RTCresetRemove();
+}
+
+void RTC_Handler(void)
+{
+  RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0; // must clear flag at end
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -171,6 +171,7 @@ void RTCZero::setDate(uint8_t day, uint8_t month, uint8_t year)
 void RTCZero::config32kOSC() 
 {
   SYSCTRL->XOSC32K.reg = SYSCTRL_XOSC32K_ONDEMAND |
+                         SYSCTRL_XOSC32K_RUNSTDBY |
                          SYSCTRL_XOSC32K_EN32K |
                          SYSCTRL_XOSC32K_XTALEN |
                          SYSCTRL_XOSC32K_STARTUP(6) |

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -21,6 +21,8 @@
 
 static bool __time24 = false;
 
+voidFuncPtr RTC_callBack = NULL;
+
 void RTCZero::begin(bool timeRep) 
 {
   uint16_t tmp_reg = 0;
@@ -76,6 +78,10 @@ void RTCZero::begin(bool timeRep)
 
 void RTC_Handler(void)
 {
+  if (RTC_callBack != NULL) {
+    RTC_callBack();
+  }
+
   RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0; // must clear flag at end
 }
 
@@ -91,6 +97,16 @@ void RTCZero::disableAlarm()
   RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = 0x00;
   while (RTCisSyncing())
     ;
+}
+
+void RTCZero::attachInterrupt(voidFuncPtr callback)
+{
+  RTC_callBack = callback;
+}
+
+void RTCZero::detachInterrupt()
+{
+  RTC_callBack = NULL;
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -112,6 +112,36 @@ uint8_t RTCZero::getYear()
   return RTC->MODE2.CLOCK.bit.YEAR;
 }
 
+uint8_t RTCZero::getAlarmSeconds()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.SECOND;
+}
+
+uint8_t RTCZero::getAlarmMinutes()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.MINUTE;
+}
+
+uint8_t RTCZero::getAlarmHours()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR;
+}
+
+uint8_t RTCZero::getAlarmDay()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.DAY;
+}
+
+uint8_t RTCZero::getAlarmMonth()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.MONTH;
+}
+
+uint8_t RTCZero::getAlarmYear()
+{
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.YEAR;
+}
+
 /*
  * Set Functions
  */
@@ -174,6 +204,67 @@ void RTCZero::setDate(uint8_t day, uint8_t month, uint8_t year)
   setDay(day);
   setMonth(month);
   setYear(year);
+}
+
+void RTCZero::setAlarmSeconds(uint8_t seconds)
+{
+  RTC->MODE2.Mode2Alarm[0].ALARM.bit.SECOND = seconds;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmMinutes(uint8_t minutes)
+{
+  RTC->MODE2.Mode2Alarm[0].ALARM.bit.MINUTE = minutes;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmHours(uint8_t hours)
+{
+  if ((__time24) || (hours < 13)) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR = hours;
+  }
+  else {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR = hours - 12;
+  }
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds)
+{
+  setAlarmSeconds(seconds);
+  setAlarmMinutes(minutes);
+  setAlarmHours(hours);
+}
+
+void RTCZero::setAlarmDay(uint8_t day)
+{
+  RTC->MODE2.Mode2Alarm[0].ALARM.bit.DAY = day;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmMonth(uint8_t month)
+{
+  RTC->MODE2.Mode2Alarm[0].ALARM.bit.MONTH = month;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmYear(uint8_t year)
+{
+  RTC->MODE2.Mode2Alarm[0].ALARM.bit.YEAR = year;
+  while (RTCisSyncing())
+    ;
+}
+
+void RTCZero::setAlarmDate(uint8_t day, uint8_t month, uint8_t year)
+{
+  setAlarmDay(day);
+  setAlarmMonth(month);
+  setAlarmYear(year);
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -119,7 +119,7 @@ void RTCZero::setMinutes(uint8_t minutes)
 
 void RTCZero::setHours(uint8_t hours)
 {
-  if (__time24) {
+  if ((__time24) || (hours < 13)) {
     RTC->MODE2.CLOCK.bit.HOUR = hours;
   } else {
     RTC->MODE2.CLOCK.bit.HOUR = hours - 12;

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -29,15 +29,15 @@ typedef void(*voidFuncPtr)(void);
 class RTCZero {
 public:
 
-  enum Alarm_Match: uint8_t
+  enum Alarm_Match: uint8_t // Should we have this enum or just use the identifiers from /component/rtc.h ?
   {
-    MATCH_OFF          = 0x00,
-    MATCH_SS           = 0x01,
-    MATCH_MMSS         = 0x02,
-    MATCH_HHMMSS       = 0x03,
-    MATCH_DHHMMSS      = 0x04,
-    MATCH_MMDDHHMMSS   = 0x05,
-    MATCH_YYMMDDHHMMSS = 0x06
+    MATCH_OFF          = RTC_MODE2_MASK_SEL_OFF_Val,
+    MATCH_SS           = RTC_MODE2_MASK_SEL_SS_Val,
+    MATCH_MMSS         = RTC_MODE2_MASK_SEL_MMSS_Val,
+    MATCH_HHMMSS       = RTC_MODE2_MASK_SEL_HHMMSS_Val,
+    MATCH_DHHMMSS      = RTC_MODE2_MASK_SEL_DDHHMMSS_Val,
+    MATCH_MMDDHHMMSS   = RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val,
+    MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val
   };
 
   RTCZero() {};

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -40,6 +40,14 @@ public:
   uint8_t getMonth();
   uint8_t getYear();
 
+  uint8_t getAlarmSeconds();
+  uint8_t getAlarmMinutes();
+  uint8_t getAlarmHours();
+
+  uint8_t getAlarmDay();
+  uint8_t getAlarmMonth();
+  uint8_t getAlarmYear();
+
   /* Set Functions */
 
   void setSeconds(uint8_t seconds);
@@ -51,6 +59,16 @@ public:
   void setMonth(uint8_t month);
   void setYear(uint8_t year);
   void setDate(uint8_t day, uint8_t month, uint8_t year);
+
+  void setAlarmSeconds(uint8_t seconds);
+  void setAlarmMinutes(uint8_t minutes);
+  void setAlarmHours(uint8_t hours);
+  void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+
+  void setAlarmDay(uint8_t day);
+  void setAlarmMonth(uint8_t month);
+  void setAlarmYear(uint8_t year);
+  void setAlarmDate(uint8_t day, uint8_t month, uint8_t year);
 
 private:
   void config32kOSC(void);

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -27,8 +27,22 @@
 class RTCZero {
 public:
 
+  enum Alarm_Match: uint8_t
+  {
+    MATCH_OFF          = 0x00,
+    MATCH_SS           = 0x01,
+    MATCH_MMSS         = 0x02,
+    MATCH_HHMMSS       = 0x03,
+    MATCH_DHHMMSS      = 0x04,
+    MATCH_MMDDHHMMSS   = 0x05,
+    MATCH_YYMMDDHHMMSS = 0x06
+  };
+
   RTCZero() {};
   void begin(bool timeRep);
+
+  void enableAlarm(Alarm_Match match);
+  void disableAlarm();
   
   /* Get Functions */
 

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -24,6 +24,8 @@
 
 #include "Arduino.h"
 
+typedef void(*voidFuncPtr)(void);
+
 class RTCZero {
 public:
 
@@ -43,6 +45,9 @@ public:
 
   void enableAlarm(Alarm_Match match);
   void disableAlarm();
+
+  void attachInterrupt(voidFuncPtr callback);
+  void detachInterrupt();
   
   /* Get Functions */
 


### PR DESCRIPTION
First commit fixes a bug in setHours() (if hours < 13 and in 12h mode).

The main additions add the ability to set an interrupt based alarm which can call a user specified callback. It will work in sleep mode and the alarm will wake the board. Alarm masking is implemented to create periodic alarms.