### PR TITLE
Added Epoch Support

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -107,7 +107,7 @@ void RTCZero::disableAlarm()
     ;
 }
 
-void RTCZero::attachInterrupt(RTC_voidFuncPtr callback)
+void RTCZero::attachInterrupt(voidFuncPtr callback)
 {
   RTC_callBack = callback;
 }

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -19,8 +19,7 @@
  
 #include "RTCZero.h"
 
-#define EPOCH_TIME_OFF 946684800  // This is 2000-jan-01 00:00:00 in epoch time
-#define SECONDS_PER_DAY 86400L
+#define EPOCH_TIME_OFF 946684800  // This is 1st January 2000, 00:00:00 in epoch time
 
 static const uint8_t daysInMonth[12] = { 31,28,31,30,31,30,31,31,30,31,30,31 };
 

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -128,9 +128,7 @@ uint8_t RTCZero::getMinutes()
 
 uint8_t RTCZero::getHours()
 {
-  uint8_t hours = RTC->MODE2.CLOCK.bit.HOUR;
-
-  return hours;
+  return RTC->MODE2.CLOCK.bit.HOUR;
 }
 
 uint8_t RTCZero::getDay()
@@ -160,9 +158,7 @@ uint8_t RTCZero::getAlarmMinutes()
 
 uint8_t RTCZero::getAlarmHours()
 {
-  uint8_t hours = RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR;
-
-  return hours;
+  return RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR;
 }
 
 uint8_t RTCZero::getAlarmDay()

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -108,8 +108,12 @@ void RTCZero::detachInterrupt()
 
 void RTCZero::standbyMode()
 {
-	SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
-  __WFI();
+  // Entering standby mode when connected
+  // via the native USB port causes issues
+  if (!SerialUSB) {
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    __WFI();
+  }
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -408,7 +408,12 @@ uint32_t RTCZero::getY2kEpoch()
 
 void RTCZero::setEpoch(uint32_t ts)
 {
-  setY2kEpoch(ts - EPOCH_TIME_OFF);
+  if (ts < EPOCH_TIME_OFF) {
+    setY2kEpoch(0);
+  }
+  else {
+    setY2kEpoch(ts - EPOCH_TIME_OFF);
+  }
 }
 
 void RTCZero::setY2kEpoch(uint32_t ts)

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -109,11 +109,9 @@ void RTCZero::detachInterrupt()
 void RTCZero::standbyMode()
 {
   // Entering standby mode when connected
-  // via the native USB port causes issues
-  if (!SerialUSB) {
-    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
-    __WFI();
-  }
+  // via the native USB port causes issues.
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+  __WFI();
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -108,7 +108,7 @@ void RTCZero::disableAlarm()
     ;
 }
 
-void RTCZero::attachInterrupt(voidFuncPtr callback)
+void RTCZero::attachInterrupt(RTC_voidFuncPtr callback)
 {
   RTC_callBack = callback;
 }

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -25,7 +25,7 @@
 
 #include "Arduino.h"
 
-typedef void(*voidFuncPtr)(void);
+typedef void(*RTC_voidFuncPtr)(void);
 
 class RTCZero {
 public:
@@ -53,7 +53,7 @@ public:
   void enableAlarm(Alarm_Match match);
   void disableAlarm();
 
-  void attachInterrupt(voidFuncPtr callback);
+  void attachInterrupt(RTC_voidFuncPtr callback);
   void detachInterrupt();
   
   /* Get Functions */

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -47,7 +47,7 @@ public:
     MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val  // Once, on a specific date and a specific time
   };
 
-  RTCZero() {};
+  RTCZero();
   void begin(bool timeRep);
 
   void enableAlarm(Alarm_Match match);
@@ -106,6 +106,8 @@ public:
   void setY2kEpoch(uint32_t ts);
 
 private:
+  bool _time24;
+
   void config32kOSC(void);
   bool RTCisSyncing(void);
   void RTCdisable();

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -17,7 +17,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#pragma once
+#ifndef RTC_ZERO_H
+#define RTC_ZERO_H
 
 #define H24 1
 #define H12 0
@@ -31,13 +32,13 @@ public:
 
   enum Alarm_Match: uint8_t // Should we have this enum or just use the identifiers from /component/rtc.h ?
   {
-    MATCH_OFF          = RTC_MODE2_MASK_SEL_OFF_Val,
-    MATCH_SS           = RTC_MODE2_MASK_SEL_SS_Val,
-    MATCH_MMSS         = RTC_MODE2_MASK_SEL_MMSS_Val,
-    MATCH_HHMMSS       = RTC_MODE2_MASK_SEL_HHMMSS_Val,
-    MATCH_DHHMMSS      = RTC_MODE2_MASK_SEL_DDHHMMSS_Val,
-    MATCH_MMDDHHMMSS   = RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val,
-    MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val
+    MATCH_OFF          = RTC_MODE2_MASK_SEL_OFF_Val,          // Never
+    MATCH_SS           = RTC_MODE2_MASK_SEL_SS_Val,           // Every Minute
+    MATCH_MMSS         = RTC_MODE2_MASK_SEL_MMSS_Val,         // Every Hour
+    MATCH_HHMMSS       = RTC_MODE2_MASK_SEL_HHMMSS_Val,       // Every Day
+    MATCH_DHHMMSS      = RTC_MODE2_MASK_SEL_DDHHMMSS_Val,     // Every Month
+    MATCH_MMDDHHMMSS   = RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val,   // Every Year
+    MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val  // Once, on a specific date and a specific time
   };
 
   RTCZero() {};
@@ -89,6 +90,13 @@ public:
   void setAlarmYear(uint8_t year);
   void setAlarmDate(uint8_t day, uint8_t month, uint8_t year);
 
+  /* Epoch Functions */
+
+  uint32_t getEpoch();
+  uint32_t getY2kEpoch();
+  void setEpoch(uint32_t ts);
+  void setY2kEpoch(uint32_t ts);
+
 private:
   void config32kOSC(void);
   bool RTCisSyncing(void);
@@ -97,3 +105,5 @@ private:
   void RTCreset();
   void RTCresetRemove();
 };
+
+#endif // RTC_ZERO_H

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -30,6 +30,12 @@ typedef void(*voidFuncPtr)(void);
 class RTCZero {
 public:
 
+  enum RTC_AM_PM : uint8_t
+  {
+    RTC_AM = 0,
+    RTC_PM = 1
+  };
+
   enum Alarm_Match: uint8_t // Should we have this enum or just use the identifiers from /component/rtc.h ?
   {
     MATCH_OFF          = RTC_MODE2_MASK_SEL_OFF_Val,          // Never
@@ -55,14 +61,16 @@ public:
   uint8_t getSeconds();
   uint8_t getMinutes();
   uint8_t getHours();
+  uint8_t getAM_PM();
   
   uint8_t getDay();
   uint8_t getMonth();
   uint8_t getYear();
-
+  
   uint8_t getAlarmSeconds();
   uint8_t getAlarmMinutes();
   uint8_t getAlarmHours();
+  uint8_t getAlarmAM_PM();
 
   uint8_t getAlarmDay();
   uint8_t getAlarmMonth();
@@ -72,8 +80,8 @@ public:
 
   void setSeconds(uint8_t seconds);
   void setMinutes(uint8_t minutes);
-  void setHours(uint8_t hours);
-  void setTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+  void setHours(uint8_t hours, uint8_t am_pm = RTC_AM);
+  void setTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint8_t am_pm = RTC_AM);
 
   void setDay(uint8_t day);
   void setMonth(uint8_t month);
@@ -82,8 +90,8 @@ public:
 
   void setAlarmSeconds(uint8_t seconds);
   void setAlarmMinutes(uint8_t minutes);
-  void setAlarmHours(uint8_t hours);
-  void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+  void setAlarmHours(uint8_t hours, uint8_t am_pm = RTC_AM);
+  void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint8_t am_pm = RTC_AM);
 
   void setAlarmDay(uint8_t day);
   void setAlarmMonth(uint8_t month);

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -25,7 +25,7 @@
 
 #include "Arduino.h"
 
-typedef void(*RTC_voidFuncPtr)(void);
+typedef void(*voidFuncPtr)(void);
 
 class RTCZero {
 public:
@@ -53,7 +53,7 @@ public:
   void enableAlarm(Alarm_Match match);
   void disableAlarm();
 
-  void attachInterrupt(RTC_voidFuncPtr callback);
+  void attachInterrupt(voidFuncPtr callback);
   void detachInterrupt();
   
   /* Get Functions */

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -20,9 +20,6 @@
 #ifndef RTC_ZERO_H
 #define RTC_ZERO_H
 
-#define H24 1
-#define H12 0
-
 #include "Arduino.h"
 
 typedef void(*voidFuncPtr)(void);


### PR DESCRIPTION
Updated 23/11/15
Removed: [Added full H12 AM/PM support for setting the hours value (also for querying).]

Previously the RTC_MODE2_CTRL_CLKREP bit was not being set correctly (inverted).

Added the ability to get or set the time and date using either a Epoch or Y2K timestamp.
Epoch timestamps are clamped to Y2K lower bound.

Removed: [A few other modifications including renaming the function pointer type to avoid possible
conflicts and moving the __time24 into the class.]

