### PR TITLE
Several Fixes and Additions

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -40,6 +40,7 @@ void RTCZero::begin(bool resetTime)
 
   // If the RTC is in clock mode and the reset was
   // not due to POR or BOD, preserve the clock time
+  // POR causes a reset anyway, BOD behaviour is?
   bool validTime = false;
   RTC_MODE2_CLOCK_Type oldTime;
 

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -303,17 +303,21 @@ void RTCZero::setAlarmDate(uint8_t day, uint8_t month, uint8_t year)
 
 uint32_t RTCZero::getEpoch()
 {
+  RTCreadRequest();
+  RTC_MODE2_CLOCK_Type clockTime;
+  clockTime.reg = RTC->MODE2.CLOCK.reg;
+
   struct tm tm;
 
   tm.tm_isdst = -1;
   tm.tm_yday = 0;
   tm.tm_wday = 0;
-  tm.tm_year = getYear() + EPOCH_TIME_YEAR_OFF;
-  tm.tm_mon = getMonth() - 1;
-  tm.tm_mday = getDay();
-  tm.tm_hour = getHours();
-  tm.tm_min = getMinutes();
-  tm.tm_sec = getSeconds();
+  tm.tm_year = clockTime.bit.YEAR + EPOCH_TIME_YEAR_OFF;
+  tm.tm_mon = clockTime.bit.MONTH - 1;
+  tm.tm_mday = clockTime.bit.DAY;
+  tm.tm_hour = clockTime.bit.HOUR;
+  tm.tm_min = clockTime.bit.MINUTE;
+  tm.tm_sec = clockTime.bit.SECOND;
 
   return mktime(&tm);
 }
@@ -365,7 +369,7 @@ void RTCZero::config32kOSC()
 
 /* Synchronise the CLOCK register for reading*/
 inline void RTCZero::RTCreadRequest() {
-  RTC->MODE2.READREQ.reg |= RTC_READREQ_RREQ;
+  RTC->MODE2.READREQ.reg = RTC_READREQ_RREQ | RTC_READREQ_ADDR(0x10);
   while (RTCisSyncing())
     ;
 }

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -121,31 +121,37 @@ void RTCZero::standbyMode()
 
 uint8_t RTCZero::getSeconds()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.SECOND;
 }
 
 uint8_t RTCZero::getMinutes()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.MINUTE;
 }
 
 uint8_t RTCZero::getHours()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.HOUR;
 }
 
 uint8_t RTCZero::getDay()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.DAY;
 }
 
 uint8_t RTCZero::getMonth()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.MONTH;
 }
 
 uint8_t RTCZero::getYear()
 {
+  RTCreadRequest();
   return RTC->MODE2.CLOCK.bit.YEAR;
 }
 
@@ -355,6 +361,13 @@ void RTCZero::config32kOSC()
                          SYSCTRL_XOSC32K_XTALEN |
                          SYSCTRL_XOSC32K_STARTUP(6) |
                          SYSCTRL_XOSC32K_ENABLE;
+}
+
+/* Synchronise the CLOCK register for reading*/
+inline void RTCZero::RTCreadRequest() {
+  RTC->MODE2.READREQ.reg |= RTC_READREQ_RREQ;
+  while (RTCisSyncing())
+    ;
 }
 
 /* Wait for sync in write operations */

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -26,6 +26,11 @@
 
 voidFuncPtr RTC_callBack = NULL;
 
+RTCZero::RTCZero()
+{
+  _configured = false;
+}
+
 void RTCZero::begin() 
 {
   uint16_t tmp_reg = 0;
@@ -72,6 +77,8 @@ void RTCZero::begin()
 
   RTCenable();
   RTCresetRemove();
+
+  _configured = true;
 }
 
 void RTC_Handler(void)
@@ -369,9 +376,11 @@ void RTCZero::config32kOSC()
 
 /* Synchronise the CLOCK register for reading*/
 inline void RTCZero::RTCreadRequest() {
-  RTC->MODE2.READREQ.reg = RTC_READREQ_RREQ;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.READREQ.reg = RTC_READREQ_RREQ;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 /* Wait for sync in write operations */

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -92,16 +92,20 @@ void RTC_Handler(void)
 
 void RTCZero::enableAlarm(Alarm_Match match)
 {
-  RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = match;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = match;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::disableAlarm()
 {
-  RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = 0x00;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].MASK.bit.SEL = 0x00;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::attachInterrupt(voidFuncPtr callback)
@@ -198,114 +202,146 @@ uint8_t RTCZero::getAlarmYear()
 
 void RTCZero::setSeconds(uint8_t seconds)
 {
-  RTC->MODE2.CLOCK.bit.SECOND = seconds;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.SECOND = seconds;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setMinutes(uint8_t minutes)
 {
-  RTC->MODE2.CLOCK.bit.MINUTE = minutes;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.MINUTE = minutes;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setHours(uint8_t hours)
 {
-  RTC->MODE2.CLOCK.bit.HOUR = hours;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.HOUR = hours;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setTime(uint8_t hours, uint8_t minutes, uint8_t seconds)
 {
-  setSeconds(seconds);
-  setMinutes(minutes);
-  setHours(hours);
+  if (_configured) {
+    setSeconds(seconds);
+    setMinutes(minutes);
+    setHours(hours);
+  }
 }
 
 void RTCZero::setDay(uint8_t day)
 {
-  RTC->MODE2.CLOCK.bit.DAY = day;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.DAY = day;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setMonth(uint8_t month)
 {
-  RTC->MODE2.CLOCK.bit.MONTH = month;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.MONTH = month;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setYear(uint8_t year)
 {
-  RTC->MODE2.CLOCK.bit.YEAR = year;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.CLOCK.bit.YEAR = year;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setDate(uint8_t day, uint8_t month, uint8_t year)
 {
-  setDay(day);
-  setMonth(month);
-  setYear(year);
+  if (_configured) {
+    setDay(day);
+    setMonth(month);
+    setYear(year);
+  }
 }
 
 void RTCZero::setAlarmSeconds(uint8_t seconds)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.SECOND = seconds;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.SECOND = seconds;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmMinutes(uint8_t minutes)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.MINUTE = minutes;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.MINUTE = minutes;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmHours(uint8_t hours)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR = hours;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.HOUR = hours;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds)
 {
-  setAlarmSeconds(seconds);
-  setAlarmMinutes(minutes);
-  setAlarmHours(hours);
+  if (_configured) {
+    setAlarmSeconds(seconds);
+    setAlarmMinutes(minutes);
+    setAlarmHours(hours);
+  }
 }
 
 void RTCZero::setAlarmDay(uint8_t day)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.DAY = day;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.DAY = day;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmMonth(uint8_t month)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.MONTH = month;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.MONTH = month;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmYear(uint8_t year)
 {
-  RTC->MODE2.Mode2Alarm[0].ALARM.bit.YEAR = year;
-  while (RTCisSyncing())
-    ;
+  if (_configured) {
+    RTC->MODE2.Mode2Alarm[0].ALARM.bit.YEAR = year;
+    while (RTCisSyncing())
+      ;
+  }
 }
 
 void RTCZero::setAlarmDate(uint8_t day, uint8_t month, uint8_t year)
 {
-  setAlarmDay(day);
-  setAlarmMonth(month);
-  setAlarmYear(year);
+  if (_configured) {
+    setAlarmDay(day);
+    setAlarmMonth(month);
+    setAlarmYear(year);
+  }
 }
 
 uint32_t RTCZero::getEpoch()
@@ -336,27 +372,31 @@ uint32_t RTCZero::getY2kEpoch()
 
 void RTCZero::setEpoch(uint32_t ts)
 {
-  if (ts < EPOCH_TIME_OFF) {
-    ts = EPOCH_TIME_OFF;
+  if (_configured) {
+    if (ts < EPOCH_TIME_OFF) {
+      ts = EPOCH_TIME_OFF;
+    }
+
+    time_t t = ts;
+    struct tm* tmp = gmtime(&t);
+
+    RTC->MODE2.CLOCK.bit.YEAR = tmp->tm_year - EPOCH_TIME_YEAR_OFF;
+    RTC->MODE2.CLOCK.bit.MONTH = tmp->tm_mon + 1;
+    RTC->MODE2.CLOCK.bit.DAY = tmp->tm_mday;
+    RTC->MODE2.CLOCK.bit.HOUR = tmp->tm_hour;
+    RTC->MODE2.CLOCK.bit.MINUTE = tmp->tm_min;
+    RTC->MODE2.CLOCK.bit.SECOND = tmp->tm_sec;
+
+    while (RTCisSyncing())
+      ;
   }
-
-  time_t t = ts;
-  struct tm* tmp = gmtime(&t);
-
-  RTC->MODE2.CLOCK.bit.YEAR = tmp->tm_year - EPOCH_TIME_YEAR_OFF;
-  RTC->MODE2.CLOCK.bit.MONTH = tmp->tm_mon + 1;
-  RTC->MODE2.CLOCK.bit.DAY = tmp->tm_mday;
-  RTC->MODE2.CLOCK.bit.HOUR = tmp->tm_hour;
-  RTC->MODE2.CLOCK.bit.MINUTE = tmp->tm_min;
-  RTC->MODE2.CLOCK.bit.SECOND = tmp->tm_sec;
-
-  while (RTCisSyncing())
-    ;
 }
 
 void RTCZero::setY2kEpoch(uint32_t ts)
 {
-  setEpoch(ts + EPOCH_TIME_OFF);
+  if (_configured) {
+    setEpoch(ts + EPOCH_TIME_OFF);
+  }
 }
 
 /*

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -358,7 +358,7 @@ void RTCZero::config32kOSC()
 }
 
 /* Wait for sync in write operations */
-bool RTCZero::RTCisSyncing()
+inline bool RTCZero::RTCisSyncing()
 {
   return (RTC->MODE2.STATUS.bit.SYNCBUSY);
 }

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -369,7 +369,7 @@ void RTCZero::config32kOSC()
 
 /* Synchronise the CLOCK register for reading*/
 inline void RTCZero::RTCreadRequest() {
-  RTC->MODE2.READREQ.reg = RTC_READREQ_RREQ | RTC_READREQ_ADDR(0x10);
+  RTC->MODE2.READREQ.reg = RTC_READREQ_RREQ;
   while (RTCisSyncing())
     ;
 }

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -38,7 +38,7 @@ public:
     MATCH_YYMMDDHHMMSS = RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val  // Once, on a specific date and a specific time
   };
 
-  RTCZero() {};
+  RTCZero();
   void begin();
 
   void enableAlarm(Alarm_Match match);
@@ -99,6 +99,8 @@ public:
   void setY2kEpoch(uint32_t ts);
 
 private:
+  bool _configured;
+
   void config32kOSC(void);
   void RTCreadRequest();
   bool RTCisSyncing(void);

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -100,6 +100,7 @@ public:
 
 private:
   void config32kOSC(void);
+  void RTCreadRequest();
   bool RTCisSyncing(void);
   void RTCdisable();
   void RTCenable();

--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -39,7 +39,7 @@ public:
   };
 
   RTCZero();
-  void begin();
+  void begin(bool resetTime = false);
 
   void enableAlarm(Alarm_Match match);
   void disableAlarm();


### PR DESCRIPTION
There are a few issues address in these commits.

**1. Read operations causing the bus to stall.**
Reading from the CLOCK register can cause the bus to stall if the register is in the process of  synchronizing. The problem with this is that it can block interrupt routines during the bus stall. This issue can be seen with a UART device that constantly streams data (e.g. a GPS). The bus stalls can result in a character being dropped due to the interrupt being delayed long enough so that the UART RX register has been overwritten by the following character before the interrupt routine has been able to store it in the ring buffer.

The fix involves calling synchronization of the CLOCK register before every read operation. 

**2. Possible incorrect values from the getEpoch() method**
The getEpoch() method was reading each value from the CLOCK register. This could possibly result in an incorrect value if there was a roll over between those reads. 

The fix involves reading the CLOCK register in a single operation.

**3. Write operations when the clock in not configured**
If you attempt to set any of the time or alarm values before configuring the RTC, the device will lock up due to entering an endless loop when attempting to synchronize that register.

The solution was to add a flag which is at the end of begin(). This is tested in all of the methods which attempt to modify/write to the RTC's registers.

**4. During configuration the clock value is preserved if possible**
In the begin() method, if the last reset was not due to a loss of power (POR) or a brown out (BOD) and the RTC was previously configured in calendar mode (MODE2), the CLOCK register is preserved and restored after the configuration has been completed. An optional (and by default false) parameter to begin() will force the CLOCK register to be reset.