### PR TITLE
Fix for issue #29: Added a fix for the default CLOCK register value of 0.

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -84,11 +84,14 @@ void RTCZero::begin(bool resetTime)
   RTCresetRemove();
 
   // If desired and valid, restore the time value, else use first valid time value
-  if ((!resetTime) && (validTime)) {
+  if ((!resetTime) && (validTime) && (oldTime.reg != 0L)) {
     RTC->MODE2.CLOCK.reg = oldTime.reg;
   }
   else {
-    RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_MONTH(1) | RTC_MODE2_CLOCK_DAY(1);
+    // Change the values here to set a default date and time
+    // Use calendar year-2000, month and day values cannot be 0
+    RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_YEAR(0) | RTC_MODE2_CLOCK_MONTH(1) | RTC_MODE2_CLOCK_DAY(1)
+        | RTC_MODE2_CLOCK_HOUR(0) | RTC_MODE2_CLOCK_MINUTE(0) | RTC_MODE2_CLOCK_SECOND(0);
   }
   while (RTCisSyncing())
     ;

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -83,12 +83,15 @@ void RTCZero::begin(bool resetTime)
   RTCenable();
   RTCresetRemove();
 
-  // If desired and valid, restore the time value
+  // If desired and valid, restore the time value, else use first valid time value
   if ((!resetTime) && (validTime)) {
     RTC->MODE2.CLOCK.reg = oldTime.reg;
-    while (RTCisSyncing())
-      ;
   }
+  else {
+    RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_MONTH(1) | RTC_MODE2_CLOCK_DAY(1);
+  }
+  while (RTCisSyncing())
+    ;
 
   _configured = true;
 }

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -24,6 +24,14 @@
 #define EPOCH_TIME_OFF      946684800  // This is 1st January 2000, 00:00:00 in epoch time
 #define EPOCH_TIME_YEAR_OFF 100        // years since 1900
 
+// Default date & time after reset
+#define DEFAULT_YEAR    2000    // 2000..2063
+#define DEFAULT_MONTH   1       // 1..12
+#define DEFAULT_DAY     1       // 1..31
+#define DEFAULT_HOUR    0       // 1..23
+#define DEFAULT_MINUTE  0       // 0..59
+#define DEFAULT_SECOND  0       // 0..59
+
 voidFuncPtr RTC_callBack = NULL;
 
 RTCZero::RTCZero()
@@ -88,10 +96,9 @@ void RTCZero::begin(bool resetTime)
     RTC->MODE2.CLOCK.reg = oldTime.reg;
   }
   else {
-    // Change the values here to set a default date and time
-    // Use calendar year-2000, month and day values cannot be 0
-    RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_YEAR(0) | RTC_MODE2_CLOCK_MONTH(1) | RTC_MODE2_CLOCK_DAY(1)
-        | RTC_MODE2_CLOCK_HOUR(0) | RTC_MODE2_CLOCK_MINUTE(0) | RTC_MODE2_CLOCK_SECOND(0);
+    RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_YEAR(DEFAULT_YEAR - 2000) | RTC_MODE2_CLOCK_MONTH(DEFAULT_MONTH) 
+        | RTC_MODE2_CLOCK_DAY(DEFAULT_DAY) | RTC_MODE2_CLOCK_HOUR(DEFAULT_HOUR) 
+        | RTC_MODE2_CLOCK_MINUTE(DEFAULT_MINUTE) | RTC_MODE2_CLOCK_SECOND(DEFAULT_SECOND);
   }
   while (RTCisSyncing())
     ;


### PR DESCRIPTION
The default CLOCK register value of 0 is not a valid time. When the RTC
was reset (either by POR or by the user's choice), the start value of 0
was invalid. This automatically corrected after one second elapsed
causing a jump in the epoch time (of 1 month + 1 day).