### PR TITLE
added barrier instruction in standbyMode()

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -148,6 +148,7 @@ void RTCZero::standbyMode()
   // Entering standby mode when connected
   // via the native USB port causes issues.
   SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+  __DSB();
   __WFI();
 }
 


### PR DESCRIPTION
I'm proposing this change as is implemented  in https://github.com/arduino-libraries/ArduinoLowPower/blob/master/src/samd/ArduinoLowPower.cpp#L27
I have been experiencing board freeze without it.