### PR TITLE
Calling setEpoch causes serial data / interrupts to be lost

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -148,6 +148,7 @@ void RTCZero::standbyMode()
   // Entering standby mode when connected
   // via the native USB port causes issues.
   SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+  __DSB();
   __WFI();
 }
 

--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -420,12 +420,16 @@ void RTCZero::setEpoch(uint32_t ts)
     time_t t = ts;
     struct tm* tmp = gmtime(&t);
 
-    RTC->MODE2.CLOCK.bit.YEAR = tmp->tm_year - EPOCH_TIME_YEAR_OFF;
-    RTC->MODE2.CLOCK.bit.MONTH = tmp->tm_mon + 1;
-    RTC->MODE2.CLOCK.bit.DAY = tmp->tm_mday;
-    RTC->MODE2.CLOCK.bit.HOUR = tmp->tm_hour;
-    RTC->MODE2.CLOCK.bit.MINUTE = tmp->tm_min;
-    RTC->MODE2.CLOCK.bit.SECOND = tmp->tm_sec;
+    RTC_MODE2_CLOCK_Type clockTime;
+
+    clockTime.bit.YEAR = tmp->tm_year - EPOCH_TIME_YEAR_OFF;
+    clockTime.bit.MONTH = tmp->tm_mon + 1;
+    clockTime.bit.DAY = tmp->tm_mday;
+    clockTime.bit.HOUR = tmp->tm_hour;
+    clockTime.bit.MINUTE = tmp->tm_min;
+    clockTime.bit.SECOND = tmp->tm_sec;
+
+    RTC->MODE2.CLOCK.reg = clockTime.reg;
 
     while (RTCisSyncing())
       ;


### PR DESCRIPTION
Calling setEpoch causes serial data to be lost.  This is because the CLOCK register is altered bit by bit sequentially without the SYNCBUSY bit being checked with each update.

This causes a bus stall and serial interrupts to be lost.  As per the datasheet - section 19.6.8 (Synchronization):

"When executing an operation that requires synchronization, the Synchronization Busy bit in the Status register (STATUS.SYNCBUSY) will be set immediately, and cleared when synchronization is complete....
If an operation that requires synchronization is executed while STATUS.SYNCBUSY is one, the bus will be stalled...
Clock Value register (CLOCK)"

These changes fix this by changing all the single bit change updates into one register change followed by a SYNCBUSY check.