### PR TITLE
Add getAlarmEpoch() method and fix warning on compiling with oldTime.RTC_MODE2_CLOCK_Type::reg

### DIFF
--- a/src/RTCZero.h
+++ b/src/RTCZero.h
@@ -92,7 +92,8 @@ public:
   /* Epoch Functions */
 
   time_t getEpoch();
-  uint32_t getY2kEpoch();
+  time_t getY2kEpoch();
+  time_t getAlarmEpoch();
   void setEpoch(uint32_t ts);
   void setY2kEpoch(uint32_t ts);
   void setAlarmEpoch(uint32_t ts);


### PR DESCRIPTION
Add getAlarmEpoch() method : https://github.com/arduino-libraries/RTCZero/issues/60

Fix warning on compiling with oldTime.RTC_MODE2_CLOCK_Type::reg : https://github.com/arduino-libraries/RTCZero/issues/67