### PR TITLE
Correct header file name in documentation

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -5,7 +5,7 @@ This library allows an enables an Arduino based on SAMD architectures (es. [Zero
 To use this library
 
 ``` arduino
-#include <RTC.h>
+#include <RTCZero.h>
 ```
 
 ## Examples


### PR DESCRIPTION
The documentation previously specified that the header file `RTC.h` be used in an `#include` directive to use the library. This library does not contain a file of that name. The only header file is named `RTCZero.h`.

Originally reported at https://forum.arduino.cc/t/another-typo-in-documentation-it-can-t-be/952298