### PR TITLE
Disable SAMD21 SysTick interrupt during sleep

### DIFF
--- a/src/RTCZero.cpp
+++ b/src/RTCZero.cpp
@@ -145,11 +145,15 @@ void RTCZero::detachInterrupt()
 
 void RTCZero::standbyMode()
 {
+  // Disable systick interrupt
+  SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
   // Entering standby mode when connected
   // via the native USB port causes issues.
   SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
   __DSB();
   __WFI();
+  // Enable systick interrupt
+  SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;
 }
 
 /*


### PR DESCRIPTION
This addresses a problem I experienced using an Adafruit Feather M0 where the board would suddenly refuse to wake up after a random time (4 - 12 hours). I found the solution in a discussion on the Atmel community forum: https://community.atmel.com/comment/2625116#comment-2625116.

In summary, due to a hardware bug on the SAMD21 platform it is possible for the SysTick interrupt to fire during wakeup before the RAM has had time to reinitialise which results in a hard fault. This can be prevented by disabling the SysTick interrupt before sleep and then reenabling it immediately after wakeup.

```
SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;  // Disable SysTick interrupt
__DSB();   // Data sync to ensure outgoing memory accesses complete
__WFI();   // Wait for interrupt (places device in sleep mode)
SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk;   // Enable SysTick interrupt
```

After making this change the board has now been running for over two weeks with no problems.